### PR TITLE
Migrate to GitHub Container Registry (GHCR)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,17 +16,28 @@ jobs:
 
       - name: Set variables
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: |
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=docker_image::ghcr.io/netwerk-digitaal-erfgoed/network-of-terms-api"
 
-      - name: Build and push image to GitHub Packages
-        uses: docker/build-push-action@v1.1.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker registry
+        uses: docker/login-action@v1
         with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: netwerk-digitaal-erfgoed/network-of-terms-comunica/network-of-terms-comunica
-          tag_with_ref: true
-          tags: ${{ steps.vars.outputs.sha_short }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CONTAINER_REGISTRY_TOKEN }}
+
+      - name: Build and push image to registry
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.sha_short }}
+            ${{ steps.vars.outputs.docker_image }}:latest
 
       - uses: digitalocean/action-doctl@v2
         with:
@@ -38,7 +49,7 @@ jobs:
       # See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment
       - name: Update deployment
         run: |
-          kubectl set image deployment/network-of-terms-comunica network-of-terms-comunica=docker.pkg.github.com/netwerk-digitaal-erfgoed/network-of-terms-comunica/network-of-terms-comunica:${{ steps.vars.outputs.sha_short }} --record
+          kubectl set image deployment/network-of-terms-api app=${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.sha_short }} --record
 
       - name: Verify deployment
-        run: kubectl rollout status deployment/network-of-terms-comunica
+        run: kubectl rollout status deployment/network-of-terms-api


### PR DESCRIPTION
* GHCR is replacing GitHub Packages for Docker images.
* This enables us to make the image public.
* Rename Docker image to network-of-terms-api.