### PR TITLE
fix: resolve source errors

### DIFF
--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -78,7 +78,7 @@ export class QueryTermsService {
       config
     )) as IActorQueryOperationOutputQuads;
 
-    return new Promise((resolve /*, reject */) => {
+    return new Promise(resolve => {
       const termsTransformer = new TermsTransformer();
       result.quadStream.on('error', (error: Error) => {
         this.logger.error(

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -80,7 +80,12 @@ export class QueryTermsService {
 
     return new Promise((resolve, reject) => {
       const termsTransformer = new TermsTransformer();
-      result.quadStream.on('error', reject);
+      result.quadStream.on('error', (error: Error) => {
+        this.logger.error(
+          `An error occurred when querying "${this.distribution.endpoint}": ${error}`
+        );
+        resolve({distribution: this.distribution, terms: []});
+      });
       result.quadStream.on('data', (quad: RDF.Quad) =>
         termsTransformer.fromQuad(quad)
       );

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -78,7 +78,7 @@ export class QueryTermsService {
       config
     )) as IActorQueryOperationOutputQuads;
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve /*, reject */) => {
       const termsTransformer = new TermsTransformer();
       result.quadStream.on('error', (error: Error) => {
         this.logger.error(


### PR DESCRIPTION
Fix #34.

@ddeboer This is a first shot at [34](https://github.com/netwerk-digitaal-erfgoed/network-of-terms-api/issues/34) and open to debate.

Some background:

1. The issue is indeed caused by `Promise.all()`.
2. We could fix it with `Promise.allSettled()`, i.e. by removing the source that failed and continuing with the sources that succeeded. However, this way the user doesn't get to see the failed source in the response (e.g. GraphQL output), which is somewhat strange: if I query two sources and one of these fails, I still would like to see that source in the response (otherwise it suggests that the failed source wasn't queried at all).
3. The PR ensures that all sources resolve, even if one of these failed (in which case an empty result set is returned). We could improve this by also returning the error of the source (e.g. as part of the `QueryResult` interface in [query.ts](https://github.com/netwerk-digitaal-erfgoed/network-of-terms-api/blob/master/src/services/query.ts#L33)).
