### PR TITLE
feat: Return errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ query Terms {
     }
     result {
       __typename 
-      ... on Success {
+      ... on Terms {
         terms {
           uri
           prefLabel
@@ -179,7 +179,7 @@ query Terms {
     }
     result {
       __typename
-      ... on Success {
+      ... on Terms {
         terms {
           uri
           prefLabel

--- a/README.md
+++ b/README.md
@@ -133,23 +133,31 @@ query Terms {
         alternateName
       }
     }
-    terms {
-      uri
-      prefLabel
-      altLabel
-      hiddenLabel
-      scopeNote
-      broader {
-        uri
-        prefLabel
+    result {
+      __typename 
+      ... on Success {
+        terms {
+          uri
+          prefLabel
+          altLabel
+          hiddenLabel
+          scopeNote
+          broader {
+            uri
+            prefLabel
+          }
+          narrower {
+            uri
+            prefLabel
+          }
+          related {
+            uri
+            prefLabel
+          }
+        }
       }
-      narrower {
-        uri
-        prefLabel
-      }
-      related {
-        uri
-        prefLabel
+      ... on Error {
+        message
       }
     }
   }
@@ -169,12 +177,20 @@ query Terms {
         alternateName
       }
     }
-    terms {
-      uri
-      prefLabel
-      altLabel
-      hiddenLabel
-      scopeNote
+    result {
+      __typename
+      ... on Success {
+        terms {
+          uri
+          prefLabel
+          altLabel
+          hiddenLabel
+          scopeNote
+        }
+      }
+      ... on Error {
+        message
+      }
     }
   }
 }

--- a/src/commands/sources/query.ts
+++ b/src/commands/sources/query.ts
@@ -2,7 +2,7 @@ import {cli} from 'cli-ux';
 import {Command, flags} from '@oclif/command';
 import {DistributionsService} from '../../services/distributions';
 import * as Logger from '../../helpers/logger';
-import {QueryResult} from '../../services/query';
+import {QueryError, QueryResult} from '../../services/query';
 import * as RDF from 'rdf-js';
 import {Term} from '../../services/terms';
 import {Catalog, IRI} from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
@@ -38,6 +38,10 @@ export class QuerySourcesCommand extends Command {
 
   protected render(results: QueryResult[], catalog: Catalog): void {
     const rowsPerDistribution = results.map((result: QueryResult): Row[] => {
+      if (result instanceof QueryError) {
+        return [];
+      }
+
       return result.terms.map(
         (term: Term): Row => {
           return {

--- a/src/commands/sources/query.ts
+++ b/src/commands/sources/query.ts
@@ -2,7 +2,7 @@ import {cli} from 'cli-ux';
 import {Command, flags} from '@oclif/command';
 import {DistributionsService} from '../../services/distributions';
 import * as Logger from '../../helpers/logger';
-import {Error, Result} from '../../services/query';
+import {Error, TermsResult} from '../../services/query';
 import * as RDF from 'rdf-js';
 import {Term} from '../../services/terms';
 import {Catalog, IRI} from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
@@ -36,8 +36,8 @@ export class QuerySourcesCommand extends Command {
     }),
   };
 
-  protected render(results: Result[], catalog: Catalog): void {
-    const rowsPerDistribution = results.map((result: Result): Row[] => {
+  protected render(results: TermsResult[], catalog: Catalog): void {
+    const rowsPerDistribution = results.map((result: TermsResult): Row[] => {
       if (result instanceof Error) {
         return [];
       }

--- a/src/commands/sources/query.ts
+++ b/src/commands/sources/query.ts
@@ -2,7 +2,7 @@ import {cli} from 'cli-ux';
 import {Command, flags} from '@oclif/command';
 import {DistributionsService} from '../../services/distributions';
 import * as Logger from '../../helpers/logger';
-import {QueryError, QueryResult} from '../../services/query';
+import {Error, Result} from '../../services/query';
 import * as RDF from 'rdf-js';
 import {Term} from '../../services/terms';
 import {Catalog, IRI} from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
@@ -36,9 +36,9 @@ export class QuerySourcesCommand extends Command {
     }),
   };
 
-  protected render(results: QueryResult[], catalog: Catalog): void {
-    const rowsPerDistribution = results.map((result: QueryResult): Row[] => {
-      if (result instanceof QueryError) {
+  protected render(results: Result[], catalog: Catalog): void {
+    const rowsPerDistribution = results.map((result: Result): Row[] => {
+      if (result instanceof Error) {
         return [];
       }
 

--- a/src/server/resolvers.ts
+++ b/src/server/resolvers.ts
@@ -1,5 +1,5 @@
 import {DistributionsService} from '../services/distributions';
-import {Error, Result, ServerError, TimeoutError} from '../services/query';
+import {Error, TermsResult, ServerError, TimeoutError} from '../services/query';
 import * as RDF from 'rdf-js';
 import {Term} from '../services/terms';
 import {
@@ -28,7 +28,7 @@ async function queryTerms(object: any, args: any, context: any): Promise<any> {
     ),
     query: args.query,
   });
-  return results.map((result: Result) => {
+  return results.map((result: TermsResult) => {
     if (result instanceof Error) {
       return {
         source: source(
@@ -99,8 +99,8 @@ export const resolvers = {
     sources: listSources,
     terms: queryTerms,
   },
-  Result: {
-    resolveType(result: Result) {
+  TermsResult: {
+    resolveType(result: TermsResult) {
       if (result instanceof TimeoutError) {
         return 'TimeoutError';
       }
@@ -109,7 +109,7 @@ export const resolvers = {
         return 'ServerError';
       }
 
-      return 'Success';
+      return 'Terms';
     },
   },
 };

--- a/src/server/resolvers.ts
+++ b/src/server/resolvers.ts
@@ -1,10 +1,5 @@
 import {DistributionsService} from '../services/distributions';
-import {
-  QueryError,
-  QueryResult,
-  ServerError,
-  TimeoutError,
-} from '../services/query';
+import {Error, Result, ServerError, TimeoutError} from '../services/query';
 import * as RDF from 'rdf-js';
 import {Term} from '../services/terms';
 import {
@@ -33,8 +28,8 @@ async function queryTerms(object: any, args: any, context: any): Promise<any> {
     ),
     query: args.query,
   });
-  return results.map((result: QueryResult) => {
-    if (result instanceof QueryError) {
+  return results.map((result: Result) => {
+    if (result instanceof Error) {
       return {
         source: source(
           result.distribution,
@@ -105,7 +100,7 @@ export const resolvers = {
     terms: queryTerms,
   },
   Result: {
-    resolveType(result: QueryResult) {
+    resolveType(result: Result) {
       if (result instanceof TimeoutError) {
         return 'TimeoutError';
       }

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -30,11 +30,30 @@ export const schema = `
 
   type Terms {
     source: Source!
-    terms: [Term]!
+    terms: [Term]! @deprecated(reason: "Use 'result' instead")
+    result: Result!
   }
 
   type Query {
     terms(sources: [ID]!, query: String!): [Terms]
     sources: [Source]
+  }
+  
+  union Result = Success | TimeoutError | ServerError
+  
+  type Success {
+    terms: [Term]
+  }
+  
+  type TimeoutError implements Error {
+    message: String!
+  }
+  
+  type ServerError implements Error {
+    message: String!
+  }
+  
+  interface Error {
+    message: String!
   }
 `;

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -28,20 +28,20 @@ export const schema = `
     prefLabel: [String]!
   }
 
-  type Terms {
+  type TermsQueryResult {
     source: Source!
     terms: [Term]! @deprecated(reason: "Use 'result' instead")
-    result: Result!
+    result: TermsResult!
   }
 
   type Query {
-    terms(sources: [ID]!, query: String!): [Terms]
+    terms(sources: [ID]!, query: String!): [TermsQueryResult]
     sources: [Source]
   }
   
-  union Result = Success | TimeoutError | ServerError
+  union TermsResult = Terms | TimeoutError | ServerError
   
-  type Success {
+  type Terms {
     terms: [Term]
   }
   

--- a/src/services/distributions.ts
+++ b/src/services/distributions.ts
@@ -1,6 +1,6 @@
 import * as Joi from '@hapi/joi';
 import Pino from 'pino';
-import {Result, QueryTermsService} from './query';
+import {TermsResult, QueryTermsService} from './query';
 import {Catalog, IRI} from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
 import {IActorInitSparqlArgs} from '@comunica/actor-init-sparql/lib/ActorInitSparql-browser';
 
@@ -48,7 +48,7 @@ export class DistributionsService {
     this.comunica = args.comunica;
   }
 
-  async query(options: QueryOptions): Promise<Result> {
+  async query(options: QueryOptions): Promise<TermsResult> {
     const args = Joi.attempt(options, schemaQuery);
     this.logger.info(`Preparing to query source "${args.source}"...`);
     const dataset = await this.catalog.getDatasetByDistributionIri(args.source);
@@ -65,7 +65,7 @@ export class DistributionsService {
     return queryService.run();
   }
 
-  async queryAll(options: QueryAllOptions): Promise<Result[]> {
+  async queryAll(options: QueryAllOptions): Promise<TermsResult[]> {
     const args = Joi.attempt(options, schemaQueryAll);
     const requests = args.sources.map((source: IRI) =>
       this.query({source, query: args.query})

--- a/src/services/distributions.ts
+++ b/src/services/distributions.ts
@@ -1,6 +1,6 @@
 import * as Joi from '@hapi/joi';
 import Pino from 'pino';
-import {QueryResult, QueryTermsService} from './query';
+import {Result, QueryTermsService} from './query';
 import {Catalog, IRI} from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
 import {IActorInitSparqlArgs} from '@comunica/actor-init-sparql/lib/ActorInitSparql-browser';
 
@@ -48,7 +48,7 @@ export class DistributionsService {
     this.comunica = args.comunica;
   }
 
-  async query(options: QueryOptions): Promise<QueryResult> {
+  async query(options: QueryOptions): Promise<Result> {
     const args = Joi.attempt(options, schemaQuery);
     this.logger.info(`Preparing to query source "${args.source}"...`);
     const dataset = await this.catalog.getDatasetByDistributionIri(args.source);
@@ -65,7 +65,7 @@ export class DistributionsService {
     return queryService.run();
   }
 
-  async queryAll(options: QueryAllOptions): Promise<QueryResult[]> {
+  async queryAll(options: QueryAllOptions): Promise<Result[]> {
     const args = Joi.attempt(options, schemaQueryAll);
     const requests = args.sources.map((source: IRI) =>
       this.query({source, query: args.query})

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -30,23 +30,17 @@ const schemaConstructor = Joi.object({
   comunica: Joi.object().required(),
 });
 
-export type QueryResult = Success | TimeoutError | ServerError;
-
-class Result {
-  constructor(readonly distribution: Distribution) {}
-}
+export type Result = Success | TimeoutError | ServerError;
 
 export class Success {
   constructor(readonly distribution: Distribution, readonly terms: Term[]) {}
 }
 
-export class QueryError extends Result {
-  constructor(readonly distribution: Distribution, readonly message: string) {
-    super(distribution);
-  }
+export class Error {
+  constructor(readonly distribution: Distribution, readonly message: string) {}
 }
-export class TimeoutError extends QueryError {}
-export class ServerError extends QueryError {}
+export class TimeoutError extends Error {}
+export class ServerError extends Error {}
 
 export class QueryTermsService {
   protected logger: Pino.Logger;
@@ -79,7 +73,7 @@ export class QueryTermsService {
     };
   }
 
-  async run(): Promise<QueryResult> {
+  async run(): Promise<Result> {
     this.logger.info(
       `Querying "${this.distribution.endpoint}" with "${this.query}"...`
     );

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -30,9 +30,9 @@ const schemaConstructor = Joi.object({
   comunica: Joi.object().required(),
 });
 
-export type Result = Success | TimeoutError | ServerError;
+export type TermsResult = Terms | TimeoutError | ServerError;
 
-export class Success {
+export class Terms {
   constructor(readonly distribution: Distribution, readonly terms: Term[]) {}
 }
 
@@ -73,7 +73,7 @@ export class QueryTermsService {
     };
   }
 
-  async run(): Promise<Result> {
+  async run(): Promise<TermsResult> {
     this.logger.info(
       `Querying "${this.distribution.endpoint}" with "${this.query}"...`
     );
@@ -101,7 +101,7 @@ export class QueryTermsService {
             this.distribution.endpoint
           }" in ${PrettyMilliseconds(timer.elapsed())}`
         );
-        resolve(new Success(this.distribution, terms));
+        resolve(new Terms(this.distribution, terms));
       });
     });
   }


### PR DESCRIPTION
* Fix #52.
* Add two error classes: `ServerError` (which we already use)
  and `TimeoutError` (which we can start using when we support
  timeouts).
* Deprecate `terms` but don’t remove it yet to prevent BC breaks.
  Recommend `result` instead.
