### PR TITLE
feat: Add query timeout

### DIFF
--- a/src/commands/sources/query.ts
+++ b/src/commands/sources/query.ts
@@ -93,6 +93,7 @@ export class QuerySourcesCommand extends Command {
     const results = await service.queryAll({
       sources,
       query: flags.query,
+      timeoutMs: parseInt(process.env.QUERY_TIMEOUT as string) || 10000,
     });
     this.render(results, catalog);
   }

--- a/src/commands/sources/query.ts
+++ b/src/commands/sources/query.ts
@@ -34,6 +34,10 @@ export class QuerySourcesCommand extends Command {
       required: false,
       default: 'warn',
     }),
+    timeout: flags.integer({
+      description: 'Query timeout in ms',
+      required: false,
+    }),
   };
 
   protected render(results: TermsResult[], catalog: Catalog): void {
@@ -93,7 +97,7 @@ export class QuerySourcesCommand extends Command {
     const results = await service.queryAll({
       sources,
       query: flags.query,
-      timeoutMs: parseInt(process.env.QUERY_TIMEOUT as string) || 10000,
+      timeoutMs: flags.timeout,
     });
     this.render(results, catalog);
   }

--- a/src/server/resolvers.ts
+++ b/src/server/resolvers.ts
@@ -27,6 +27,7 @@ async function queryTerms(object: any, args: any, context: any): Promise<any> {
       (distributionIri: string) => new IRI(distributionIri)
     ),
     query: args.query,
+    timeoutMs: parseInt(process.env.QUERY_TIMEOUT as string) || 10000,
   });
   return results.map((result: TermsResult) => {
     if (result instanceof Error) {

--- a/src/server/resolvers.ts
+++ b/src/server/resolvers.ts
@@ -27,7 +27,7 @@ async function queryTerms(object: any, args: any, context: any): Promise<any> {
       (distributionIri: string) => new IRI(distributionIri)
     ),
     query: args.query,
-    timeoutMs: parseInt(process.env.QUERY_TIMEOUT as string) || 10000,
+    timeoutMs: args.timeoutMs,
   });
   return results.map((result: TermsResult) => {
     if (result instanceof Error) {

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -35,7 +35,7 @@ export const schema = `
   }
 
   type Query {
-    terms(sources: [ID]!, query: String!): [TermsQueryResult]
+    terms(sources: [ID]!, query: String!, timeoutMs: Int = 10000): [TermsQueryResult]
     sources: [Source]
   }
   

--- a/src/services/distributions.ts
+++ b/src/services/distributions.ts
@@ -1,6 +1,6 @@
 import * as Joi from '@hapi/joi';
 import Pino from 'pino';
-import {TermsResult, QueryTermsService} from './query';
+import {QueryTermsService, TermsResult} from './query';
 import {Catalog, IRI} from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
 import {IActorInitSparqlArgs} from '@comunica/actor-init-sparql/lib/ActorInitSparql-browser';
 
@@ -19,21 +19,25 @@ const schemaConstructor = Joi.object({
 export interface QueryOptions {
   source: IRI;
   query: string;
+  timeoutMs: number;
 }
 
 const schemaQuery = Joi.object({
   source: Joi.object().required(),
   query: Joi.string().required(),
+  timeoutMs: Joi.number().required(),
 });
 
 export interface QueryAllOptions {
   sources: IRI[];
   query: string;
+  timeoutMs: number;
 }
 
 const schemaQueryAll = Joi.object({
   sources: Joi.array().items(Joi.object().required()).min(1).required(),
   query: Joi.string().required(),
+  timeoutMs: Joi.number().required(),
 });
 
 export class DistributionsService {
@@ -61,6 +65,7 @@ export class DistributionsService {
       comunica: this.comunica,
       distribution,
       query: args.query,
+      timeoutMs: args.timeoutMs,
     });
     return queryService.run();
   }
@@ -68,7 +73,7 @@ export class DistributionsService {
   async queryAll(options: QueryAllOptions): Promise<TermsResult[]> {
     const args = Joi.attempt(options, schemaQueryAll);
     const requests = args.sources.map((source: IRI) =>
-      this.query({source, query: args.query})
+      this.query({source, query: args.query, timeoutMs: args.timeoutMs})
     );
     return Promise.all(requests);
   }

--- a/src/services/distributions.ts
+++ b/src/services/distributions.ts
@@ -25,7 +25,7 @@ export interface QueryOptions {
 const schemaQuery = Joi.object({
   source: Joi.object().required(),
   query: Joi.string().required(),
-  timeoutMs: Joi.number().required(),
+  timeoutMs: Joi.number().integer(),
 });
 
 export interface QueryAllOptions {
@@ -37,7 +37,7 @@ export interface QueryAllOptions {
 const schemaQueryAll = Joi.object({
   sources: Joi.array().items(Joi.object().required()).min(1).required(),
   query: Joi.string().required(),
-  timeoutMs: Joi.number().required(),
+  timeoutMs: Joi.number().integer(),
 });
 
 export class DistributionsService {

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -21,6 +21,7 @@ export interface ConstructorOptions {
   distribution: Distribution;
   query: string;
   comunica: IActorInitSparqlArgs;
+  timeoutMs: number;
 }
 
 const schemaConstructor = Joi.object({
@@ -28,6 +29,7 @@ const schemaConstructor = Joi.object({
   distribution: Joi.object().required(),
   query: Joi.string().required(),
   comunica: Joi.object().required(),
+  timeoutMs: Joi.number().required(),
 });
 
 export type TermsResult = Terms | TimeoutError | ServerError;
@@ -39,7 +41,11 @@ export class Terms {
 export class Error {
   constructor(readonly distribution: Distribution, readonly message: string) {}
 }
-export class TimeoutError extends Error {}
+export class TimeoutError extends Error {
+  constructor(readonly distribution: Distribution, timeoutMs: number) {
+    super(distribution, `Source timed out after ${timeoutMs}ms`);
+  }
+}
 export class ServerError extends Error {}
 
 export class QueryTermsService {
@@ -47,6 +53,7 @@ export class QueryTermsService {
   protected distribution: Distribution;
   protected query: string;
   protected engine: ActorInitSparql;
+  protected timeoutMs: number;
 
   constructor(options: ConstructorOptions) {
     const args = Joi.attempt(options, schemaConstructor);
@@ -54,6 +61,7 @@ export class QueryTermsService {
     this.distribution = args.distribution;
     this.query = args.query;
     this.engine = args.comunica;
+    this.timeoutMs = args.timeoutMs;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -83,27 +91,31 @@ export class QueryTermsService {
       this.getConfig()
     )) as IActorQueryOperationOutputQuads;
 
-    return new Promise(resolve => {
-      const termsTransformer = new TermsTransformer();
-      result.quadStream.on('error', (error: Error) => {
-        this.logger.error(
-          `An error occurred when querying "${this.distribution.endpoint}": ${error}`
+    return guardTimeout(
+      new Promise(resolve => {
+        const termsTransformer = new TermsTransformer();
+        result.quadStream.on('error', (error: Error) => {
+          this.logger.error(
+            `An error occurred when querying "${this.distribution.endpoint}": ${error}`
+          );
+          resolve(new ServerError(this.distribution, error.message));
+        });
+        result.quadStream.on('data', (quad: RDF.Quad) =>
+          termsTransformer.fromQuad(quad)
         );
-        resolve(new ServerError(this.distribution, error.message));
-      });
-      result.quadStream.on('data', (quad: RDF.Quad) =>
-        termsTransformer.fromQuad(quad)
-      );
-      result.quadStream.on('end', () => {
-        const terms = termsTransformer.asArray().sort(alphabeticallyByLabels);
-        this.logger.info(
-          `Found ${terms.length} terms matching "${this.query}" in "${
-            this.distribution.endpoint
-          }" in ${PrettyMilliseconds(timer.elapsed())}`
-        );
-        resolve(new Terms(this.distribution, terms));
-      });
-    });
+        result.quadStream.on('end', () => {
+          const terms = termsTransformer.asArray().sort(alphabeticallyByLabels);
+          this.logger.info(
+            `Found ${terms.length} terms matching "${this.query}" in "${
+              this.distribution.endpoint
+            }" in ${PrettyMilliseconds(timer.elapsed())}`
+          );
+          resolve(new Terms(this.distribution, terms));
+        });
+      }),
+      this.timeoutMs,
+      new TimeoutError(this.distribution, this.timeoutMs)
+    );
   }
 }
 
@@ -116,3 +128,16 @@ const alphabeticallyByLabels = (a: Term, b: Term) => {
   const sortLabelB = prefLabelB + altLabelB;
   return sortLabelA.localeCompare(sortLabelB);
 };
+
+function guardTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutError: TimeoutError
+): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise(resolve =>
+      setTimeout(resolve.bind(null, timeoutError), timeoutMs)
+    ),
+  ]) as Promise<T>;
+}

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -29,7 +29,10 @@ const schemaConstructor = Joi.object({
   distribution: Joi.object().required(),
   query: Joi.string().required(),
   comunica: Joi.object().required(),
-  timeoutMs: Joi.number().required(),
+  timeoutMs: Joi.number()
+    .integer()
+    .max(parseInt(process.env.MAX_QUERY_TIMEOUT as string) || 10000)
+    .default(parseInt(process.env.DEFAULT_QUERY_TIMEOUT as string) || 5000)
 });
 
 export type TermsResult = Terms | TimeoutError | ServerError;

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -31,6 +31,7 @@ const schemaConstructor = Joi.object({
   comunica: Joi.object().required(),
   timeoutMs: Joi.number()
     .integer()
+    .min(1)
     .max(parseInt(process.env.MAX_QUERY_TIMEOUT as string) || 10000)
     .default(parseInt(process.env.DEFAULT_QUERY_TIMEOUT as string) || 5000),
 });

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -32,7 +32,7 @@ const schemaConstructor = Joi.object({
   timeoutMs: Joi.number()
     .integer()
     .max(parseInt(process.env.MAX_QUERY_TIMEOUT as string) || 10000)
-    .default(parseInt(process.env.DEFAULT_QUERY_TIMEOUT as string) || 5000)
+    .default(parseInt(process.env.DEFAULT_QUERY_TIMEOUT as string) || 5000),
 });
 
 export type TermsResult = Terms | TimeoutError | ServerError;


### PR DESCRIPTION
* Fix #45.
* Use `Promise.race` to set a timeout on each outgoing request.
* Configurable through `DEFAULT_QUERY_TIMEOUT` and `MAX_QUERY_TIMEOUT`
  env vars; respectively 5 and 10 sec.