### PR TITLE
fix: URL type error

### DIFF
--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -64,7 +64,7 @@ export class QueryTermsService {
       sources: [
         {
           type: 'sparql', // Only supported type for now
-          value: this.distribution.endpoint,
+          value: this.distribution.endpoint.toString(),
         },
       ],
       initialBindings: Bindings({


### PR DESCRIPTION
```
TypeError [ERR_INVALID_ARG_TYPE]: The \"url\" argument must be of type
string. Received an instance of IRI"}
```