### PR TITLE
Replace GraphQL playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Search results are piped to stdout. Redirect these elsewhere for further analysi
 
 ### Open the GraphQL editor
 
-http://localhost:3123/playground
+http://localhost:3123/graphiql
 
 ### List queryable sources
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -35,6 +35,15 @@ async function startServer(): Promise<void> {
       reply.redirect('/graphiql');
     },
   });
+
+  // Redirect /playground to /graphiql for BC.
+  server.route({
+    method: 'GET',
+    url: '/playground',
+    handler: (req, reply) => {
+      reply.redirect(302, '/graphiql');
+    },
+  });
   await server.listen(3123, '0.0.0.0');
 }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -18,7 +18,7 @@ async function startServer(): Promise<void> {
   server.register(mercurius, {
     schema,
     resolvers,
-    graphiql: 'playground',
+    graphiql: true,
     context: (): Promise<object> =>
       new Promise(resolve => {
         resolve({
@@ -32,7 +32,7 @@ async function startServer(): Promise<void> {
     method: 'GET',
     url: '/',
     handler: (req, reply) => {
-      reply.redirect('/playground');
+      reply.redirect('/graphiql');
     },
   });
   await server.listen(3123, '0.0.0.0');


### PR DESCRIPTION
The playground was removed in Mercurius 8.0
(https://github.com/mercurius-js/mercurius/pull/453). Instead, Mercurius
ships with GraphiQL, so enable that.